### PR TITLE
Remove ambertools to allow windows build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 05cfa136b7ca16418f156724c8ab9199b89d25dd9f92133108796034563ca685
 
 build:
-  number: 1
-  skip: true  # [win]
+  number: 2
   script: "{{ PYTHON }} -m pip install . -vv --no-deps"
   entry_points:
   - test-openmm-platforms = openmmtools.scripts.test_openmm_platforms:main
@@ -32,7 +31,6 @@ requirements:
     - setuptools
     - jinja2
     - six
-    - ambertools
     - mdtraj
     - netcdf4 >=1.4.2
     - libnetcdf >=4.6.2


### PR DESCRIPTION
Try to resolve #4 by removing what appears to be an unnecessary dependence on `ambertools`.